### PR TITLE
CORL-1674 - updated story get query to add metadata fields

### DIFF
--- a/src/commands/story/get.ts
+++ b/src/commands/story/get.ts
@@ -8,6 +8,12 @@ export const GetStoryQuery = /* GraphQL */ `
       status
       metadata {
         title
+        description
+        image
+        author
+        publishedAt
+        modifiedAt
+        section
       }
       commentCounts {
         totalPublished


### PR DESCRIPTION
Updated the `story:get` query to return all metadata fields if available in Coral. Testing shows that `null` will be returned for any values that are not present on the `story` document in Coral/mongo. 

